### PR TITLE
Update README for v0.11.x branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Terraform module for scheduling Fargate tasks with CloudWatch Event Rules.
 ```HCL
 module "fargate-scheduled-task" {
   source  = "baikonur-oss/fargate-scheduled-task/aws"
-  version = "0.1.3"
+  version = "1.0.2"
 
   name                = "dev-batch-foo"
   schedule_expression = "cron(40 1 * * ? *)"


### PR DESCRIPTION
For details, see v1.0.1 release notes: https://github.com/baikonur-oss/terraform-aws-fargate-scheduled-task/releases/tag/v1.0.1

From now on, we will release v0.11.x compatible versions from `v0.11.x` branch