### PR TITLE
Update README for v0.12.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 Terraform module for scheduling Fargate tasks with CloudWatch Event Rules.
 
-![terraform v0.11.x](https://img.shields.io/badge/terraform-v0.11.x-brightgreen.svg)
 ![terraform v0.12.x](https://img.shields.io/badge/terraform-v0.12.x-brightgreen.svg)
 
 ## Usage
@@ -10,7 +9,7 @@ Terraform module for scheduling Fargate tasks with CloudWatch Event Rules.
 ```HCL
 module "fargate-scheduled-task" {
   source  = "baikonur-oss/fargate-scheduled-task/aws"
-  version = "v1.0.0"
+  version = "v2.0.0"
 
   name                = "dev-batch-foo"
   schedule_expression = "cron(40 1 * * ? *)"


### PR DESCRIPTION
For details, see v1.0.1 release notes: https://github.com/baikonur-oss/terraform-aws-fargate-scheduled-task/releases/tag/v1.0.1

As it turns out v1.0.0 did not support v0.11.x in some scenarios, we will drop v0.11.x support on master altogether. Because module will only support v0.12.x, we should use v2.x tags on releases.