### PR TITLE
0.12 upgrade (syntax, pre-commit hooks)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: git://github.com/antonbabenko/pre-commit-terraform
-  rev: v1.7.3
+  rev: v1.16.0
   hooks:
     - id: terraform_fmt
     - id: terraform_docs

--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ For more information on module version pinning, see [Selecting a Revision](https
 | is\_enabled | Rule enabled flag | string | `"true"` | no |
 | name | CloudWatch Event Rule name | string | n/a | yes |
 | schedule\_expression | CloudWatch schedule expression (see: https://docs.aws.amazon.com/ja_jp/AmazonCloudWatch/latest/events/ScheduledEvents.html ) | string | n/a | yes |
-| security\_group\_ids | List of security group ids for Fargate task ENI | list | n/a | yes |
-| subnet\_ids | List of subnet ids for Fargate task ENI | list | n/a | yes |
+| security\_group\_ids | List of security group ids for Fargate task ENI | list(string) | n/a | yes |
+| subnet\_ids | List of subnet ids for Fargate task ENI | list(string) | n/a | yes |
 | target\_cluster\_arn | Target ECS cluster ARN | string | n/a | yes |
 | task\_count | Number of tasks to execute at once | string | `"1"` | no |
 | task\_definition\_arn | ARN of Task Definition to run | string | n/a | yes |

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Terraform module for scheduling Fargate tasks with CloudWatch Event Rules.
 ```HCL
 module "fargate-scheduled-task" {
   source  = "baikonur-oss/fargate-scheduled-task/aws"
-  version = "v2.0.0"
+  version = "v2.0.1"
 
   name                = "dev-batch-foo"
   schedule_expression = "cron(40 1 * * ? *)"
@@ -17,8 +17,8 @@ module "fargate-scheduled-task" {
 
   target_cluster_arn = "dev"
 
-  task_definition_arn = "${aws_ecs_task_definition.ecs_task_definition.arn}"
-  task_role_arn       = "${module.iam_ecs_tasks.arn}"
+  task_definition_arn = aws_ecs_task_definition.ecs_task_definition.arn
+  task_role_arn       = module.iam_ecs_tasks.arn
   task_count          = "1"
 
   subnet_ids         = ["subnet-***1", "subnet-***2"]
@@ -26,10 +26,10 @@ module "fargate-scheduled-task" {
 }
 
 module "iam_ecs_tasks" {
-  source = "baikonur-oss/iam-nofile/aws"
+  source  = "baikonur-oss/iam-nofile/aws"
   version = "1.0.2"
-  type = "ecs-tasks"
-  name = "dev-batch"
+  type    = "ecs-tasks"
+  name    = "dev-batch"
 
   policy_json = <<EOF
 {

--- a/main.tf
+++ b/main.tf
@@ -1,28 +1,28 @@
 # CloudWatch Event on Fargate
 
 locals {
-  iam_ecs_run_task_resource = "${var.iam_ecs_run_task_resource != "" ? var.iam_ecs_run_task_resource : var.task_definition_arn}"
+  iam_ecs_run_task_resource = var.iam_ecs_run_task_resource != "" ? var.iam_ecs_run_task_resource : var.task_definition_arn
 }
 
 resource "aws_cloudwatch_event_rule" "schedule_rule" {
-  name                = "${var.name}"
-  schedule_expression = "${var.schedule_expression}"
-  is_enabled          = "${var.is_enabled}"
+  name                = var.name
+  schedule_expression = var.schedule_expression
+  is_enabled          = var.is_enabled
 }
 
 resource "aws_cloudwatch_event_target" "fargate_scheduled_task" {
-  rule     = "${aws_cloudwatch_event_rule.schedule_rule.name}"
-  arn      = "${var.target_cluster_arn}"
-  role_arn = "${module.iam.arn}"
+  rule     = aws_cloudwatch_event_rule.schedule_rule.name
+  arn      = var.target_cluster_arn
+  role_arn = module.iam.arn
 
   ecs_target {
-    task_definition_arn = "${var.task_definition_arn}"
-    task_count          = "${var.task_count}"
+    task_definition_arn = var.task_definition_arn
+    task_count          = var.task_count
     launch_type         = "FARGATE"
 
     network_configuration {
-      subnets          = "${var.subnet_ids}"
-      security_groups  = "${var.security_group_ids}"
+      subnets          = var.subnet_ids
+      security_groups  = var.security_group_ids
       assign_public_ip = true
     }
   }
@@ -32,7 +32,7 @@ module "iam" {
   source  = "baikonur-oss/iam-nofile/aws"
   version = "1.0.2"
   type    = "events"
-  name    = "${var.name}"
+  name    = var.name
 
   policy_json = <<EOF
 {
@@ -60,4 +60,6 @@ module "iam" {
     ]
 }
 EOF
+
 }
+

--- a/variables.tf
+++ b/variables.tf
@@ -26,12 +26,12 @@ variable "task_count" {
 
 variable "subnet_ids" {
   description = "List of subnet ids for Fargate task ENI"
-  type        = "list"
+  type        = list(string)
 }
 
 variable "security_group_ids" {
   description = "List of security group ids for Fargate task ENI"
-  type        = "list"
+  type        = list(string)
 }
 
 variable "task_role_arn" {
@@ -46,3 +46,4 @@ variable "iam_ecs_run_task_resource" {
   description = "Field for overriding ecs:RunTask resource identifier in Events IAM role (defaults to task_definition_arn)"
   default     = ""
 }
+

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
Break 0.11 support and upgrade to 0.12.

Same as:
- https://github.com/baikonur-oss/terraform-aws-lambda-kinesis-to-es/pull/6
- https://github.com/baikonur-oss/terraform-aws-lambda-kinesis-to-s3/pull/5